### PR TITLE
feat: support for topic as source

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,11 +32,11 @@ There are two files mandatory for the bot to work `.env` and `chat_list.json`.
 
 Template env may be found in `sample.env`. Rename it to `.env` and fill in the values:
 
--   `BOT_TOKEN` - Telegram bot token. You can get it from [@BotFather](https://t.me/BotFather)
+- `BOT_TOKEN` - Telegram bot token. You can get it from [@BotFather](https://t.me/BotFather)
 
--   `OWNER_ID` - An integer of consisting of your owner ID.
+- `OWNER_ID` - An integer of consisting of your owner ID.
 
--   `REMOVE_TAG` - set to `True` if you want to remove the tag ("Forwarded from xxxxx") from the forwarded message.
+- `REMOVE_TAG` - set to `True` if you want to remove the tag ("Forwarded from xxxxx") from the forwarded message.
 
 #### `chat_list.json`
 
@@ -46,17 +46,23 @@ This file contains the list of chats to forward messages from and to. The bot ex
 
 ```json
 [
-    {
-        "source": -10012345678,
-        "destination": [-10011111111, "-10022222222#123456"]
-    }
+  {
+    "source": -10012345678,
+    "destination": [-10011111111, "-10022222222#123456"]
+  },
+  {
+    "source": "-10087654321#000000",  // Topic/Forum group
+    "destination": ["-10033333333#654321"]
+  }
 ]
 ```
 
--   `source` - The chat ID of the chat to forward messages from. It can be a group or a channel.
+- `source` - The chat ID of the chat to forward messages from. It can be a group or a channel.
 
--   `destination` - An array of chat IDs to forward messages to. It can be a group or a channel.
-    > Destenation supports Topics chat. You can use `#topicID` string to forward to specific topic. Example: `[-10011111111, "-10022222222#123456"]`. With this config it will forward to chat `-10022222222` with topic `123456` and to chat `-10011111111` .
+  > If the source chat is a Topic groups, you **MUST** explicitly specify the topic ID. The bot will ignore incoming message from topic group if the topic ID is not specified.
+
+- `destination` - An array of chat IDs to forward messages to. It can be a group or a channel.
+  > Destenation supports Topics chat. You can use `#topicID` string to forward to specific topic. Example: `[-10011111111, "-10022222222#123456"]`. With this config it will forward to chat `-10022222222` with topic `123456` and to chat `-10011111111` .
 
 You may add as many objects as you want. The bot will forward messages from all the chats in the `source` field to all the chats in the `destination` field. Duplicates are allowed as it already handled by the bot.
 
@@ -80,8 +86,8 @@ This will install all necessary python packages.
 
 #### Requrements
 
--   Docker
--   docker compose
+- Docker
+- docker compose
 
 Before launch make sure all configuration are completed (`.env` and `chat_list.json`)!
 
@@ -99,4 +105,4 @@ docker compose logs -f
 
 ### Credits
 
--   [AutoForwarder-TelegramBot](https://github.com/saksham2410/AutoForwarder-TelegramBot)
+- [AutoForwarder-TelegramBot](https://github.com/saksham2410/AutoForwarder-TelegramBot)

--- a/forwarder/modules/forward.py
+++ b/forwarder/modules/forward.py
@@ -5,7 +5,7 @@ from telegram.error import ChatMigrated
 from telegram.ext import MessageHandler, filters, ContextTypes
 
 from forwarder import bot, REMOVE_TAG, LOGGER
-from forwarder.utils import get_source, get_destenation, parse_topic
+from forwarder.utils import get_source, get_destenation
 
 
 async def send_message(
@@ -23,7 +23,7 @@ async def forwarder(update: Update, _: ContextTypes.DEFAULT_TYPE) -> None:
     if not message or not source:
         return
 
-    for chat in get_destenation(source.id):
+    for chat in get_destenation(message.chat_id, message.message_thread_id):
         try:
             await send_message(message, chat["chat_id"], thread_id=chat["thread_id"])
         except ChatMigrated as err:

--- a/forwarder/utils/chat.py
+++ b/forwarder/utils/chat.py
@@ -22,11 +22,18 @@ def get_source() -> List[ChatConfig]:
     return [parse_topic(chat["source"]) for chat in CONFIG]
 
 
-def get_destenation(source: int) -> List[ChatConfig]:
+def get_destenation(chat_id: int, topic_id: Optional[int] = None) -> List[ChatConfig]:
+    """Get destination from a specific source chat
+
+    Args:
+        chat_id (`int`): source chat id
+        topic_id (`Optional[int]`): source topic id. Defaults to None.
+    """
+
     dest: List[ChatConfig] = []
 
     for chat in CONFIG:
         parsed = parse_topic(chat["source"])
-        if parsed["chat_id"] == source:
+        if parsed["chat_id"] == chat_id and (topic_id is None or parsed["thread_id"] == topic_id):
             dest.extend([parse_topic(item) for item in chat["destination"]])
     return dest


### PR DESCRIPTION
If the source chat is a Topic groups, the config **MUST** explicitly specify the topic ID. The bot will ignore incoming message from topic group if the topic ID is not specified.

Resolve #81 